### PR TITLE
Implement master process

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	fileParam := "fastq"
 	fileValues := "raw_sequence.fastq"
-	fileUsage := "the FASTQ file containing raw sequence data for assembly"
+	fileUsage := "the path to the FASTQ file containing raw sequence data for assembly"
 	rawSequenceFile := flag.String(fileParam, fileValues, fileUsage)
 
 	prepParam := "prepper"
@@ -28,5 +28,7 @@ func main() {
 		}
 	}
 	mst := master.NewMaster(*rawSequenceFile)
-	mst.Process()
+	if err := mst.Process(); err != nil {
+		panic(fmt.Sprintf("failed to run master process, err: %v", err))
+	}
 }

--- a/master/interfaces.go
+++ b/master/interfaces.go
@@ -3,6 +3,6 @@ package master
 
 // Master is the interface that defines the actions that are accessible by the user of genomagic
 type Master interface {
-	// Process launches the assembly of the contings it was created with
-	Process()
+	// Process launches the assembly of the contigs the master received for assembly
+	Process() error
 }

--- a/slave/components/assembler/assembler.go
+++ b/slave/components/assembler/assembler.go
@@ -13,8 +13,8 @@ import (
 
 // structure of the assembler
 type asmbler struct {
-	// name of the file the assembler will operate on
-	fileName string
+	// path to the file the assembler will operate on
+	filePath string
 	// the Docker client the assembler will use to spin up containers
 	dClient *client.Client
 }
@@ -23,7 +23,7 @@ type asmbler struct {
 // TODO: this needs to take in an assembler name
 func NewAssembler(fnm string) (components.Component, error) {
 	a := &asmbler{
-		fileName: fnm,
+		filePath: fnm,
 	}
 	cli, err := client.NewEnvClient()
 	if err != nil {

--- a/slave/components/parser/parser.go
+++ b/slave/components/parser/parser.go
@@ -6,14 +6,14 @@ import (
 
 // structure of the parser
 type prser struct {
-	// name of the file the parser will operate on
-	fileName string
+	// path of the file the parser will operate on
+	filePath string
 }
 
 // NewParser creates and returns a new parser struct
 func NewParser(fnm string) (components.Component, error) {
 	return &prser{
-		fileName: fnm,
+		filePath: fnm,
 	}, nil
 }
 

--- a/slave/slave.go
+++ b/slave/slave.go
@@ -29,7 +29,7 @@ type slv struct {
 	// name/description of the work performed by the slave
 	description string
 	// the file the slave is supposed to perform work on
-	fileName string
+	filePath string
 	// the type of work that has to be performed by the slave
 	workType ComponentWorkType
 }
@@ -38,14 +38,14 @@ type slv struct {
 func NewSlave(dsc, fnm string, wtp ComponentWorkType) *slv {
 	return &slv{
 		description: dsc,
-		fileName:    fnm,
+		filePath:    fnm,
 		workType:    wtp,
 	}
 }
 
 // Process performs the work that's dictated by the master
 func (s *slv) Process() error {
-	worker, err := WorkType[s.workType](s.fileName)
+	worker, err := WorkType[s.workType](s.filePath)
 	if err != nil {
 		return fmt.Errorf("failed to initialize worker, err: %v", err)
 	}


### PR DESCRIPTION
1. Added a simple implementation of the master `Process` function
2. Renamed `fileName` to `filePath` to make it clear that we are using file paths for FASTQ files

@tayabsoomro 