### PR TITLE
Add assembler MegaHit process

### DIFF
--- a/prepper/install.go
+++ b/prepper/install.go
@@ -11,6 +11,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+
+	"github.com/genomagic/slave/components/assembler"
 )
 
 const (
@@ -20,7 +22,7 @@ const (
 // Assemblers is a mapping from an assembler DockerHub image link to an image name
 // Used for checking that allowed assembler links are passed to prep()
 var Assemblers = map[string]string{
-	MegaHit: "megahit",
+	MegaHit: assembler.MegaHit,
 }
 
 // prep holds the Docker client for pulling images

--- a/prepper/install.go
+++ b/prepper/install.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 
 	"github.com/genomagic/slave/components/assembler"
@@ -56,24 +55,6 @@ func (p *prep) prep(dImageLink string) error {
 	}
 	if _, err := io.Copy(os.Stdout, reader); err != nil {
 		return fmt.Errorf("failed to copy stdout to internal reader, err: %v", err)
-	}
-
-	resp, err := p.dClient.ContainerCreate(p.ctx, &container.Config{
-		Tty:   true,
-		Image: Assemblers[dImageLink],
-	}, nil, nil, "")
-	if err != nil {
-		return fmt.Errorf("failed to create container, err: %v", err)
-	}
-
-	if err := p.dClient.ContainerStart(p.ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
-		return fmt.Errorf("failed to start container, err: %v", err)
-	}
-
-	if status, err := p.dClient.ContainerWait(p.ctx, resp.ID); err != nil {
-		return fmt.Errorf("failed to wait for container to start up, err: %v", err)
-	} else if status != 1 {
-		return fmt.Errorf("received status code != 1, status code: %d", status)
 	}
 	return nil
 }

--- a/slave/components/assembler/assembler.go
+++ b/slave/components/assembler/assembler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+
 	"github.com/genomagic/slave/components"
 )
 
@@ -91,6 +92,7 @@ func (a *asmbler) imageExists() (bool, error) {
 
 // Process performs the work of the assembler
 func (a *asmbler) Process() error {
+	// TODO: need to pass appropriate params to the MegaHit container
 	resp, err := a.dClient.ContainerCreate(a.ctx, &container.Config{
 		Tty:     true,
 		Image:   a.assemblerName,

--- a/slave/components/assembler/assembler.go
+++ b/slave/components/assembler/assembler.go
@@ -4,46 +4,119 @@ package assembler
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"strings"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
-
 	"github.com/genomagic/slave/components"
 )
 
+const (
+	MegaHit = "megahit"
+)
+
+// AvailableAssemblers is a slice of assemblers that are currently supported
+var AvailableAssemblers = map[string]bool{MegaHit: true}
+
 // structure of the assembler
 type asmbler struct {
+	// assembler type e.g MegaHit
+	assemblerName string
 	// path to the file the assembler will operate on
 	filePath string
 	// the Docker client the assembler will use to spin up containers
 	dClient *client.Client
+	// the image ID of the struct assembler
+	dImageID string
+	// context of requests performed to the Docker daemon
+	ctx context.Context
 }
 
 // NewAssembler returns a new assembler for the specified file
-// TODO: this needs to take in an assembler name
-func NewAssembler(fnm string) (components.Component, error) {
-	a := &asmbler{
-		filePath: fnm,
+func NewAssembler(filePath, assembler string) (components.Component, error) {
+	if !AvailableAssemblers[assembler] {
+		return nil, fmt.Errorf("assembler not recognized, available assemblers: %v", AvailableAssemblers)
 	}
+
+	a := &asmbler{
+		assemblerName: assembler,
+		filePath:      filePath,
+		ctx:           context.Background(),
+	}
+
 	cli, err := client.NewEnvClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Docker client, err: %v", err)
 	} else {
 		a.dClient = cli
 	}
-	images, err := cli.ImageList(context.Background(), types.ImageListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get available Docker containers, err: %v", err)
-	}
-	// need to find whether the megahit container is available
-	// TODO: this needs to find the given assembler container and call it with appropriate params
-	for _, im := range images {
-		fmt.Printf("%s %v\n", im.ID, im.RepoTags)
+
+	if exists, err := a.imageExists(); err != nil {
+		return nil, err
+	} else if exists {
+		a.dImageID = assembler
+	} else {
+		return nil, fmt.Errorf("failed to find Dockeri image for assembler: %s", assembler)
 	}
 	return a, nil
 }
 
+// imageExists attempts to find the Docker image of the assembler that is passed to NewAssembler
+func (a *asmbler) imageExists() (bool, error) {
+	images, err := a.dClient.ImageList(a.ctx, types.ImageListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to get available Docker images, err: %v", err)
+	} else if len(images) == 0 {
+		return false, fmt.Errorf("imageExists found no images")
+	}
+	found := false
+	for _, im := range images {
+		if found {
+			break
+		}
+		for _, tag := range im.RepoTags {
+			if strings.Contains(tag, a.assemblerName) {
+				found = true
+			}
+		}
+	}
+	if !found {
+		return false, fmt.Errorf("failed to find a Docker container for the given assembler")
+	}
+	return found, nil
+}
+
 // Process performs the work of the assembler
 func (a *asmbler) Process() error {
+	resp, err := a.dClient.ContainerCreate(a.ctx, &container.Config{
+		Tty:     true,
+		Image:   a.assemblerName,
+		Cmd:     []string{""},
+		Volumes: map[string]struct{}{},
+	}, nil, nil, "")
+	if err != nil {
+		return fmt.Errorf("failed to create container, err: %v", err)
+	}
+
+	if err := a.dClient.ContainerStart(a.ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
+		return fmt.Errorf("failed to start container, err: %v", err)
+	}
+
+	if status, err := a.dClient.ContainerWait(a.ctx, resp.ID); err != nil {
+		return fmt.Errorf("failed to wait for container to start up, err: %v", err)
+	} else if status != 1 {
+		return fmt.Errorf("received status code != 1, status code: %d", status)
+	}
+	out, err := a.dClient.ContainerLogs(a.ctx, resp.ID, types.ContainerLogsOptions{ShowStdout: true})
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := io.Copy(os.Stdout, out); err != nil {
+		return fmt.Errorf("failed to capture stdout from Docker assembly container, err: %v", err)
+	}
 	return nil
 }

--- a/slave/components/assembler/assembler_test.go
+++ b/slave/components/assembler/assembler_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 )
 
+// manually testing New and Process for now
 func TestNewAssembler(t *testing.T) {
-	asm, err := NewAssembler("hello")
+	a, err := NewAssembler("", MegaHit)
 	if err != nil {
-		fmt.Printf("err in new")
-		return
+		fmt.Printf(fmt.Sprintf("err: %v", err))
 	}
-	if err := asm.Process(); err != nil {
-		fmt.Println("err")
+	err = a.Process()
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
 	}
 }

--- a/slave/components/parser/parser.go
+++ b/slave/components/parser/parser.go
@@ -11,9 +11,10 @@ type prser struct {
 }
 
 // NewParser creates and returns a new parser struct
-func NewParser(fnm string) (components.Component, error) {
+// TODO: parser needs to take in an additional param for the assembler results to process, left as _ to satisfy interface
+func NewParser(filePath, _ string) (components.Component, error) {
 	return &prser{
-		filePath: fnm,
+		filePath: filePath,
 	}, nil
 }
 

--- a/slave/slave.go
+++ b/slave/slave.go
@@ -19,7 +19,7 @@ const (
 type ComponentWorkType string
 
 // a mapping between work types and the associated components
-var WorkType = map[ComponentWorkType]func(f string) (components.Component, error){
+var WorkType = map[ComponentWorkType]func(filePath, process string) (components.Component, error){
 	Assembly: assembler.NewAssembler,
 	Parse:    parser.NewParser,
 }


### PR DESCRIPTION
1. Removed container start up from prepper's `install.go`
2. Added the ability to run MegaHit from `assembler.go`; still need to pass parameters, but at least it creates and runs the container

@tayabsoomro 