### PR TITLE
Add Docker command to assembler map

### DIFF
--- a/constants/util.go
+++ b/constants/util.go
@@ -5,10 +5,14 @@ const (
 	MegaHit = "megahit"
 )
 
+// getAssemblerCommand returns the Docker container command associated with an assembler
+type getAssemblerCommand func(i, o string) []string
+
 // assemblerDetails holds the details of each assembler
 type AssemblerDetails struct {
-	Name    string // assembler name
-	DHubURL string // DockerHub url of the assembler image
+	Name    string              // assembler name
+	DHubURL string              // DockerHub url of the assembler image
+	Comm    getAssemblerCommand // function to return the Docker command of the assembler
 }
 
 // AvailableAssemblers defines the structs of currently integrated assemblers
@@ -16,5 +20,8 @@ var AvailableAssemblers = map[string]*AssemblerDetails{
 	MegaHit: &AssemblerDetails{
 		Name:    MegaHit,
 		DHubURL: "docker.io/vout/megahit", // https://github.com/voutcn/megahit
+		Comm: func(i, o string) []string {
+			return []string{"--test"} // TODO: fill in appropriate params for MegaHit
+		},
 	},
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/genomagic/master"
 	"github.com/genomagic/prepper"
@@ -22,10 +23,14 @@ func main() {
 	prepUsage := "whether to install all the necessary Docker containers for assembly as a preparatory step"
 	prep := flag.Bool(prepParam, true, prepUsage)
 
+	outParam := "out"
+	outValue, _ := os.Getwd()
+	outUsage := "the path to the directory where results will be stored, defaults to current working directory"
+	out := flag.String(outParam, outValue, outUsage)
+
 	// parsing the flags has to be done after setting up all the flags
 	flag.Parse()
 
-	// If -fastq flag is not given, print the default usage message
 	if *rawSequenceFile == dummyFASTQ {
 		flag.PrintDefaults()
 		panic(fmt.Sprintf("the flag -fastq <path/to/sequence.fastq> is required"))
@@ -36,7 +41,7 @@ func main() {
 			panic(fmt.Sprintf("failed to prep GenoMagic, err: %v", err))
 		}
 	}
-	mst := master.NewMaster(*rawSequenceFile)
+	mst := master.NewMaster(*rawSequenceFile, *out)
 	if err := mst.Process(); err != nil {
 		panic(fmt.Sprintf("failed to run master process, err: %v", err))
 	}

--- a/master/master.go
+++ b/master/master.go
@@ -12,18 +12,17 @@ import (
 // mst defines the master struct, which is used to coordinate slaves and launch assembly, parsing, and
 // reporting slaves
 type mst struct {
-	// a path to a raw sequencing FASTQ file to perform assembly on
-	filePath string
-	// a collection of assembly results used by the assembly slave
-	assemblyResults chan slave.Result
-	// a collection of parsing results used by the parsing slave
-	parsingResults chan slave.Result
+	filePath        string            // a path to a raw sequencing FASTQ file to perform assembly on
+	outPath         string            // a path to the location where results will be stored
+	assemblyResults chan slave.Result // a collection of assembly results used by the assembly slave
+	parsingResults  chan slave.Result // a collection of parsing results used by the parsing slave
 }
 
 // NewMaster creates and returns a new master struct for the file located at the given file path
-func NewMaster(rSeqFile string) Master {
+func NewMaster(rsf, out string) Master {
 	return &mst{
-		filePath:        rSeqFile,
+		filePath:        rsf,
+		outPath:         out,
 		assemblyResults: make(chan slave.Result),
 		parsingResults:  make(chan slave.Result),
 	}
@@ -32,11 +31,11 @@ func NewMaster(rSeqFile string) Master {
 // Process launches the assembly of the contigs it was created with
 func (m *mst) Process() error {
 	// first we perform the assembly
-	assemblySlave := slave.NewSlave("assembly process initiated by master", m.filePath, slave.Assembly)
+	assemblySlave := slave.NewSlave("assembly process initiated by master", m.filePath, m.outPath, slave.Assembly)
 	if err := assemblySlave.Process(); err != nil {
 		return fmt.Errorf("slave assembly process failed with err: %v", err)
 	}
-	reportSlave := slave.NewSlave("reporting/parse process initiated by master", m.filePath, slave.Parse)
+	reportSlave := slave.NewSlave("reporting/parse process initiated by master", m.filePath, m.outPath, slave.Parse)
 	if err := reportSlave.Process(); err != nil {
 		return fmt.Errorf("slave parsing process failed with err: %v", err)
 	}

--- a/slave/components/parser/parser.go
+++ b/slave/components/parser/parser.go
@@ -12,7 +12,7 @@ type prser struct {
 
 // NewParser creates and returns a new parser struct
 // TODO: parser needs to take in an additional param for the assembler results to process, left as _ to satisfy interface
-func NewParser(filePath, _ string) (components.Component, error) {
+func NewParser(filePath, _, _ string) (components.Component, error) {
 	return &prser{
 		filePath: filePath,
 	}, nil

--- a/slave/slave.go
+++ b/slave/slave.go
@@ -20,33 +20,32 @@ const (
 type ComponentWorkType string
 
 // a mapping between work types and the associated components
-var WorkType = map[ComponentWorkType]func(filePath, process string) (components.Component, error){
+var WorkType = map[ComponentWorkType]func(fp, op, pr string) (components.Component, error){
 	Assembly: assembler.NewAssembler,
 	Parse:    parser.NewParser,
 }
 
 // slv defines the structure of a slave
 type slv struct {
-	// name/description of the work performed by the slave
-	description string
-	// the file the slave is supposed to perform work on
-	filePath string
-	// the type of work that has to be performed by the slave
-	workType ComponentWorkType
+	description string            // name/description of the work performed by the slave
+	filePath    string            // the file the slave is supposed to perform work on
+	outPath     string            // a path to the location where results will be stored
+	workType    ComponentWorkType // the type of work that has to be performed by the slave
 }
 
 // NewSlave creates and returns a new instance of a slave
-func NewSlave(dsc, fnm string, wtp ComponentWorkType) *slv {
+func NewSlave(dsc, fnm, out string, wtp ComponentWorkType) *slv {
 	return &slv{
 		description: dsc,
 		filePath:    fnm,
+		outPath:     out,
 		workType:    wtp,
 	}
 }
 
 // Process performs the work that's dictated by the master
 func (s *slv) Process() error {
-	worker, err := WorkType[s.workType](s.filePath, constants.MegaHit)
+	worker, err := WorkType[s.workType](s.filePath, s.outPath, constants.MegaHit)
 	if err != nil {
 		return fmt.Errorf("failed to initialize worker, err: %v", err)
 	}


### PR DESCRIPTION
This PR:
1. Adds a flag to `main.go` to take in a directory path where assembly results are dumped;
2. Adds an out path in master, slave, and assembler;
3. Adds a function to get command options for every assembler (MegaHit only, for now).

@tayabsoomro 