### PR TITLE
Attempt to pull all available assemblers

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,8 +37,14 @@ func main() {
 	}
 
 	if *prep {
-		if err := prepper.New(); err != nil {
-			panic(fmt.Sprintf("failed to prep GenoMagic, err: %v", err))
+		errs := prepper.New()
+		for len(errs) > 0 {
+			select {
+			case err := <-errs:
+				fmt.Printf("[WARNING] encountered error pulling Docker images, err: %v\n", err)
+			default:
+				continue
+			}
 		}
 	}
 	mst := master.New(*rawSequenceFile, *out)

--- a/prepper/install.go
+++ b/prepper/install.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -20,7 +21,10 @@ type prep struct {
 	dClient *client.Client  // Docker client
 }
 
-// New initializes a prep struct and
+// New attempts to install all the necessary Docker images for GenoMagic. New launches go routines for installing
+// the necessary images and collects the errors in a channel. When the go routines are finished, an error channel
+// is returned, with the consumer being responsible to report whether errors have occurred and alert users about
+// whether a specific assembler will be skipped
 func New() chan error {
 	ctx := context.Background()
 	errs := make(chan error, len(constants.AvailableAssemblers))
@@ -34,11 +38,18 @@ func New() chan error {
 		ctx:     ctx,
 		dClient: cli,
 	}
+
+	// we are launching the pulling of Docker containers in go routines, but we have to wait for them to finish
+	// in order to return the final error channel
+	var wg sync.WaitGroup
+	wg.Add(len(constants.AvailableAssemblers))
 	for _, aa := range constants.AvailableAssemblers {
 		go func(a *constants.AssemblerDetails) {
 			errs <- p.prep(a)
+			wg.Done()
 		}(aa)
 	}
+	wg.Wait()
 	return errs
 }
 


### PR DESCRIPTION
## Problem/related issue
Currently, the prep package, `install.go` specifically, is only attempting to install the MegaHit Docker image. 

## Proposed changes
Iterate over all available assemblers in an attempt to pull all the necessary images.

## Further comments
N/A

@tayabsoomro 