### PR TITLE
Add ability to specify threads parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ The available flags are:
         <td>No</td>
         <td>The path to the directory where results will be stored, defaults to current working directory</td>
     </tr>
+    <tr>
+            <td><code>threads</code></td>
+            <td><code>integer</code></td>
+            <td>No</td>
+            <td>The number of threads to use for assembly and output parsing processes</td>
+        </tr>
 </table>
 
 ## 5. Feedback and bug reports

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<p align="center">
-    <img src="https://user-images.githubusercontent.com/19979068/77257398-9cedfe80-6c39-11ea-890a-9167ffd1b374.png">
+<p style="align-content: center">
+    <img src="https://user-images.githubusercontent.com/19979068/77257398-9cedfe80-6c39-11ea-890a-9167ffd1b374.png" alt="">
     <br /><i>An all-encompassing Bioinformatics tool for genome assembly and annotation projects</i><br>
 </p>
 
@@ -71,11 +71,11 @@ The available flags are:
         <td>The path to the directory where results will be stored, defaults to current working directory</td>
     </tr>
     <tr>
-            <td><code>threads</code></td>
-            <td><code>integer</code></td>
-            <td>No</td>
-            <td>The number of threads to use for assembly and output parsing processes</td>
-        </tr>
+        <td><code>threads</code></td>
+        <td><code>integer</code></td>
+        <td>No</td>
+        <td>The number of threads to use for assembly and output parsing processes</td>
+    </tr>
 </table>
 
 ## 5. Feedback and bug reports

--- a/constants/util.go
+++ b/constants/util.go
@@ -29,7 +29,8 @@ const (
 )
 
 type (
-	// getAssemblerCommand returns the Docker container command associated with an assembler
+	// getAssemblerCommand returns the Docker container command associated with an assembler. The commands expects the
+	// number of thread to be specified, as assemblers can run on multiple threads
 	getAssemblerCommand func(threads int) []string
 
 	// Condition that is run by the condition command
@@ -74,7 +75,7 @@ var (
 				return []string{
 					`k=25`,
 					`name=final`,
-					fmt.Sprintf("j=%s", string(threads)),
+					fmt.Sprintf("j=%d", threads),
 					fmt.Sprintf("in='%s'", RawSeqIn),
 					fmt.Sprintf("--directory=%s", path.Join(BaseOut, AbyssOut)),
 					"contigs",

--- a/constants/util.go
+++ b/constants/util.go
@@ -59,6 +59,7 @@ var (
 				// NOTE: input filePath and outPath are mapped to Docker mounts during creation (slave/components/assembler/assembler.go:87)
 				return []string{
 					"-r", RawSeqIn,
+					fmt.Sprintf("-t %d", threads),
 					"-o", path.Join(BaseOut, MegaHitOut),
 				}
 			},
@@ -73,6 +74,7 @@ var (
 				return []string{
 					`k=25`,
 					`name=final`,
+					fmt.Sprintf("j=%s", string(threads)),
 					fmt.Sprintf("in='%s'", RawSeqIn),
 					fmt.Sprintf("--directory=%s", path.Join(BaseOut, AbyssOut)),
 					"contigs",

--- a/constants/util.go
+++ b/constants/util.go
@@ -30,7 +30,7 @@ const (
 
 type (
 	// getAssemblerCommand returns the Docker container command associated with an assembler
-	getAssemblerCommand func() []string
+	getAssemblerCommand func(threads int) []string
 
 	// Condition that is run by the condition command
 	Condition string
@@ -55,7 +55,7 @@ var (
 			DHubURL:          "docker.io/vout/megahit", // https://github.com/voutcn/megahit
 			OutputDir:        MegaHitOut,
 			AssemblyFileName: "/final.contigs.fa",
-			Comm: func() []string {
+			Comm: func(threads int) []string {
 				// NOTE: input filePath and outPath are mapped to Docker mounts during creation (slave/components/assembler/assembler.go:87)
 				return []string{
 					"-r", RawSeqIn,
@@ -69,7 +69,7 @@ var (
 			DHubURL:          "docker.io/bcgsc/abyss", // https://github.com/bcgsc/abyss
 			OutputDir:        AbyssOut,
 			AssemblyFileName: "final-contigs.fa",
-			Comm: func() []string {
+			Comm: func(threads int) []string {
 				return []string{
 					`k=25`,
 					`name=final`,

--- a/main.go
+++ b/main.go
@@ -13,8 +13,9 @@ import (
 
 const (
 	// default flag values
-	dummyFASTQ     = "dummy_sequence.fastq"
-	defaultThreads = 2
+	dummyFASTQ      = "dummy_sequence.fastq"
+	defaultThreads  = 2
+	tempThreadLimit = 10
 )
 
 func main() {
@@ -36,6 +37,9 @@ func main() {
 	threadsParam := "threads"
 	threadsUsage := "the number of threads that is passed to the assembler programs"
 	numThreads := flag.Int(threadsParam, defaultThreads, threadsUsage)
+	if *numThreads > tempThreadLimit {
+		panic(fmt.Sprintf("Cannot run with a thread number greater than %d", tempThreadLimit))
+	}
 
 	// parsing the flags has to be done after setting up all the flags
 	flag.Parse()
@@ -50,6 +54,7 @@ func main() {
 			panic(fmt.Sprintf("failed to prep GenoMagic, err: %v", err))
 		}
 	}
+
 	mst := master.New(*rawSequenceFile, *out, *numThreads)
 	if err := mst.Process(); err != nil {
 		panic(fmt.Sprintf("failed to run master process, err: %v", err))

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 			panic(fmt.Sprintf("failed to prep GenoMagic, err: %v", err))
 		}
 	}
-	mst := master.New(*rawSequenceFile, *out)
+	mst := master.New(*rawSequenceFile, *out, *numThreads)
 	if err := mst.Process(); err != nil {
 		panic(fmt.Sprintf("failed to run master process, err: %v", err))
 	}

--- a/main.go
+++ b/main.go
@@ -11,7 +11,11 @@ import (
 	"github.com/genomagic/prepper"
 )
 
-const dummyFASTQ = "dummy_sequence.fastq"
+const (
+	// default flag values
+	dummyFASTQ     = "dummy_sequence.fastq"
+	defaultThreads = 2
+)
 
 func main() {
 	fileParam := "fastq"
@@ -27,6 +31,11 @@ func main() {
 	outValue, _ := os.Getwd()
 	outUsage := "the path to the directory where results will be stored, defaults to current working directory"
 	out := flag.String(outParam, outValue, outUsage)
+
+	// TODO: add a check to make sure numThreads does not exceed the limit of host computer
+	threadsParam := "threads"
+	threadsUsage := "the number of threads that is passed to the assembler programs"
+	numThreads := flag.Int(threadsParam, defaultThreads, threadsUsage)
 
 	// parsing the flags has to be done after setting up all the flags
 	flag.Parse()

--- a/master/master.go
+++ b/master/master.go
@@ -16,15 +16,17 @@ import (
 type mst struct {
 	filePath        string             // a path to a raw sequencing FASTQ file to perform assembly on
 	outPath         string             // a path to the location where results will be stored
+	numThreads      int                // number of threads to use for slave processes
 	assemblyResults chan result.Result // a collection of assembly results used by the assembly slave
 	parsingResults  chan result.Result // a collection of parsing results used by the parsing slave
 }
 
 // New creates and returns a new master struct for the file located at the given file path
-func New(rsf, out string) Master {
+func New(rsf, out string, numThreads int) Master {
 	return &mst{
 		filePath:        rsf,
 		outPath:         out,
+		numThreads:      numThreads,
 		assemblyResults: make(chan result.Result),
 		parsingResults:  make(chan result.Result),
 	}
@@ -32,12 +34,12 @@ func New(rsf, out string) Master {
 
 // Process launches the assembly of the contigs it was created with
 func (m *mst) Process() error {
-	assemblySlave := slave.New("assembly process initiated by master", m.filePath, m.outPath, slave.Assembly)
+	assemblySlave := slave.New("assembly process initiated by master", m.filePath, m.outPath, m.numThreads, slave.Assembly)
 	if _, err := assemblySlave.Process(); err != nil {
 		return fmt.Errorf("slave assembly process failed with err: %v", err)
 	}
 
-	parserSlave := slave.New("reporting/parse process initiated by master", m.filePath, m.outPath, slave.Parse)
+	parserSlave := slave.New("reporting/parse process initiated by master", m.filePath, m.outPath, m.numThreads, slave.Parse)
 	// TODO: Take the result obtained from Parse process and feed it into the reporter
 	results, err := parserSlave.Process()
 	if err != nil {

--- a/slave/components/assembler/assembler.go
+++ b/slave/components/assembler/assembler.go
@@ -24,13 +24,14 @@ type asmbler struct {
 	assemblerName string          // assembler type e.g MegaHit
 	filePath      string          // path to the file the assembler will operate on
 	outPath       string          // path to the directory where results are stored
+	numThreads    int             // number of threads to use for assemblers
 	dClient       *client.Client  // the Docker client the assembler will use to spin up containers
 	dImageID      string          // the image ID of the struct assembler
 	ctx           context.Context // context of requests performed to the Docker daemon
 }
 
 // New returns a new assembler for the specified file
-func New(fp, op, am string) (components.Component, error) {
+func New(fp, op, am string, thrds int) (components.Component, error) {
 	if constants.AvailableAssemblers[am] == nil {
 		return nil, fmt.Errorf("assembler not recognized")
 	}
@@ -39,6 +40,7 @@ func New(fp, op, am string) (components.Component, error) {
 		assemblerName: am,
 		filePath:      fp,
 		outPath:       op,
+		numThreads:    thrds,
 		ctx:           context.Background(),
 	}
 

--- a/slave/components/assembler/assembler.go
+++ b/slave/components/assembler/assembler.go
@@ -91,7 +91,7 @@ func (a *asmbler) Process() (result.Result, error) {
 	ctConfig := &container.Config{
 		Tty:     true,
 		Image:   a.dImageID,
-		Cmd:     constants.AvailableAssemblers[a.assemblerName].Comm(),
+		Cmd:     constants.AvailableAssemblers[a.assemblerName].Comm(a.numThreads),
 		Volumes: map[string]struct{}{},
 	}
 

--- a/slave/slave.go
+++ b/slave/slave.go
@@ -29,12 +29,12 @@ type slv struct {
 }
 
 // New creates and returns a new instance of a slave
-func New(dsc, fnm, out string, thrds int, wtp ComponentWorkType) Slave {
+func New(dsc, fnm, out string, thr int, wtp ComponentWorkType) Slave {
 	return &slv{
 		description: dsc,
 		filePath:    fnm,
 		outPath:     out,
-		numThreads:  thrds,
+		numThreads:  thr,
 		workType:    wtp,
 	}
 }

--- a/slave/slave.go
+++ b/slave/slave.go
@@ -24,15 +24,17 @@ type slv struct {
 	description string            // name/description of the work performed by the slave
 	filePath    string            // the file the slave is supposed to perform work on
 	outPath     string            // a path to the location where results will be stored
+	numThreads  int               // number of threads to use for slave processes
 	workType    ComponentWorkType // the type of work that has to be performed by the slave
 }
 
 // New creates and returns a new instance of a slave
-func New(dsc, fnm, out string, wtp ComponentWorkType) Slave {
+func New(dsc, fnm, out string, thrds int, wtp ComponentWorkType) Slave {
 	return &slv{
 		description: dsc,
 		filePath:    fnm,
 		outPath:     out,
+		numThreads:  thrds,
 		workType:    wtp,
 	}
 }
@@ -41,7 +43,7 @@ func New(dsc, fnm, out string, wtp ComponentWorkType) Slave {
 func (s *slv) Process() ([]result.Result, error) {
 	if s.workType == Assembly {
 		for k := range constants.AvailableAssemblers {
-			assemblerWorker, err := assembler.New(s.filePath, s.outPath, k)
+			assemblerWorker, err := assembler.New(s.filePath, s.outPath, k, s.numThreads)
 			if err != nil {
 				return nil, fmt.Errorf("failed to initialize assembler worker, err %v", err)
 			}


### PR DESCRIPTION
## Problem/related issue

Related Issue: #50 


## Proposed changes

Added `threads` parameter which gets propagated all the way to `assembler.go` where it is passed down as a parameter `Cmd` function for each assembler. Each assembler in `util.go` then uses this parameter to specify the threads

## Further comments
