### PR TITLE
Integrate -yaml flag into GenoMagic

### DIFF
--- a/constants/util.go
+++ b/constants/util.go
@@ -4,6 +4,8 @@ package constants
 import (
 	"fmt"
 	"path"
+
+	"github.com/genomagic/config_parser"
 )
 
 const (
@@ -31,7 +33,7 @@ const (
 type (
 	// getAssemblerCommand returns the Docker container command associated with an assembler. The commands expects the
 	// number of thread to be specified, as assemblers can run on multiple threads
-	getAssemblerCommand func(threads int) []string
+	getAssemblerCommand func(threads int, config config_parser.Config) []string
 
 	// Condition that is run by the condition command
 	Condition string
@@ -56,7 +58,7 @@ var (
 			DHubURL:          "docker.io/vout/megahit", // https://github.com/voutcn/megahit
 			OutputDir:        MegaHitOut,
 			AssemblyFileName: "/final.contigs.fa",
-			Comm: func(threads int) []string {
+			Comm: func(threads int, cfg config_parser.Config) []string {
 				// NOTE: input filePath and outPath are mapped to Docker mounts during creation (slave/components/assembler/assembler.go:87)
 				return []string{
 					"-r", RawSeqIn,
@@ -71,7 +73,7 @@ var (
 			DHubURL:          "docker.io/bcgsc/abyss", // https://github.com/bcgsc/abyss
 			OutputDir:        AbyssOut,
 			AssemblyFileName: "final-contigs.fa",
-			Comm: func(threads int) []string {
+			Comm: func(threads int, cfg config_parser.Config) []string {
 				return []string{
 					`k=25`,
 					`name=final`,

--- a/constants/util.go
+++ b/constants/util.go
@@ -75,7 +75,7 @@ var (
 			AssemblyFileName: "final-contigs.fa",
 			Comm: func(cfg config_parser.Config) []string {
 				return []string{
-					fmt.Sprintf("k=%d", cfg.Assemblers.Abyss.KMers),
+					fmt.Sprintf("k=%s", cfg.Assemblers.Abyss.KMers),
 					`name=final`,
 					fmt.Sprintf("j=%d", cfg.GenoMagic.Threads),
 					fmt.Sprintf("in='%s'", RawSeqIn),

--- a/constants/util.go
+++ b/constants/util.go
@@ -75,7 +75,7 @@ var (
 			AssemblyFileName: "final-contigs.fa",
 			Comm: func(cfg config_parser.Config) []string {
 				return []string{
-					`k=25`,
+					fmt.Sprintf("k=%d", cfg.Assemblers.Abyss.KMers),
 					`name=final`,
 					fmt.Sprintf("j=%d", cfg.GenoMagic.Threads),
 					fmt.Sprintf("in='%s'", RawSeqIn),

--- a/constants/util.go
+++ b/constants/util.go
@@ -33,7 +33,7 @@ const (
 type (
 	// getAssemblerCommand returns the Docker container command associated with an assembler. The commands expects the
 	// number of thread to be specified, as assemblers can run on multiple threads
-	getAssemblerCommand func(threads int, config config_parser.Config) []string
+	getAssemblerCommand func(config config_parser.Config) []string
 
 	// Condition that is run by the condition command
 	Condition string
@@ -58,11 +58,11 @@ var (
 			DHubURL:          "docker.io/vout/megahit", // https://github.com/voutcn/megahit
 			OutputDir:        MegaHitOut,
 			AssemblyFileName: "/final.contigs.fa",
-			Comm: func(threads int, cfg config_parser.Config) []string {
+			Comm: func(cfg config_parser.Config) []string {
 				// NOTE: input filePath and outPath are mapped to Docker mounts during creation (slave/components/assembler/assembler.go:87)
 				return []string{
 					"-r", RawSeqIn,
-					fmt.Sprintf("-t %d", threads),
+					fmt.Sprintf("-t %d", cfg.GenoMagic.Threads),
 					"-o", path.Join(BaseOut, MegaHitOut),
 				}
 			},
@@ -73,11 +73,11 @@ var (
 			DHubURL:          "docker.io/bcgsc/abyss", // https://github.com/bcgsc/abyss
 			OutputDir:        AbyssOut,
 			AssemblyFileName: "final-contigs.fa",
-			Comm: func(threads int, cfg config_parser.Config) []string {
+			Comm: func(cfg config_parser.Config) []string {
 				return []string{
 					`k=25`,
 					`name=final`,
-					fmt.Sprintf("j=%d", threads),
+					fmt.Sprintf("j=%d", cfg.GenoMagic.Threads),
 					fmt.Sprintf("in='%s'", RawSeqIn),
 					fmt.Sprintf("--directory=%s", path.Join(BaseOut, AbyssOut)),
 					"contigs",

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 		}
 	}
 
-	mst := master.New(*rawSequenceFile, *out, *numThreads)
+	mst := master.New(*rawSequenceFile, *out, *numThreads, cfg)
 	if err := mst.Process(); err != nil {
 		panic(fmt.Sprintf("failed to run master process, err: %v", err))
 	}

--- a/main.go
+++ b/main.go
@@ -14,10 +14,8 @@ import (
 
 const (
 	// default flag values
-	dummyFASTQ      = "dummy_sequence.fastq"
-	dummyYAML       = "noyaml.yaml"
-	defaultThreads  = 2
-	tempThreadLimit = 10
+	dummyFASTQ = "dummy_sequence.fastq"
+	dummyYAML  = "noyaml.yaml"
 )
 
 func main() {
@@ -34,14 +32,6 @@ func main() {
 	outValue, _ := os.Getwd()
 	outUsage := "the path to the directory where results will be stored, defaults to current working directory"
 	out := flag.String(outParam, outValue, outUsage)
-
-	// TODO: add a check to make sure numThreads does not exceed the limit of host computer
-	threadsParam := "threads"
-	threadsUsage := "the number of threads that is passed to the assembler programs"
-	numThreads := flag.Int(threadsParam, defaultThreads, threadsUsage)
-	if *numThreads > tempThreadLimit {
-		panic(fmt.Sprintf("Cannot run with a thread number greater than %d", tempThreadLimit))
-	}
 
 	yamlParam := "yaml"
 	yamlValue := dummyYAML
@@ -64,7 +54,6 @@ func main() {
 		// overriding the GenoMagic core flags if a YAML file is provided
 		*rawSequenceFile = cfg.GenoMagic.InputFilePath
 		*out = cfg.GenoMagic.OutputPath
-		*numThreads = cfg.GenoMagic.Threads
 	}
 
 	if *rawSequenceFile == dummyFASTQ {
@@ -84,7 +73,7 @@ func main() {
 		}
 	}
 
-	mst := master.New(*rawSequenceFile, *out, *numThreads, cfg)
+	mst := master.New(*rawSequenceFile, *out, cfg)
 	if err := mst.Process(); err != nil {
 		panic(fmt.Sprintf("failed to run master process, err: %v", err))
 	}

--- a/master/master.go
+++ b/master/master.go
@@ -6,6 +6,7 @@ package master
 import (
 	"fmt"
 
+	"github.com/genomagic/config_parser"
 	"github.com/genomagic/reporter"
 	"github.com/genomagic/result"
 	"github.com/genomagic/slave"
@@ -14,19 +15,21 @@ import (
 // mst defines the master struct, which is used to coordinate slaves and launch assembly, parsing, and
 // reporting slaves
 type mst struct {
-	filePath        string             // a path to a raw sequencing FASTQ file to perform assembly on
-	outPath         string             // a path to the location where results will be stored
-	numThreads      int                // number of threads to use for slave processes
-	assemblyResults chan result.Result // a collection of assembly results used by the assembly slave
-	parsingResults  chan result.Result // a collection of parsing results used by the parsing slave
+	filePath        string                // a path to a raw sequencing FASTQ file to perform assembly on
+	outPath         string                // a path to the location where results will be stored
+	numThreads      int                   // number of threads to use for slave processes
+	config          *config_parser.Config // the configuration of GenoMagic obtained through YAML config file
+	assemblyResults chan result.Result    // a collection of assembly results used by the assembly slave
+	parsingResults  chan result.Result    // a collection of parsing results used by the parsing slave
 }
 
 // New creates and returns a new master struct for the file located at the given file path
-func New(rsf, out string, numThreads int) Master {
+func New(rsf, out string, numThreads int, cfg *config_parser.Config) Master {
 	return &mst{
 		filePath:        rsf,
 		outPath:         out,
 		numThreads:      numThreads,
+		config:          cfg,
 		assemblyResults: make(chan result.Result),
 		parsingResults:  make(chan result.Result),
 	}
@@ -34,12 +37,12 @@ func New(rsf, out string, numThreads int) Master {
 
 // Process launches the assembly of the contigs it was created with
 func (m *mst) Process() error {
-	assemblySlave := slave.New("assembly process initiated by master", m.filePath, m.outPath, m.numThreads, slave.Assembly)
+	assemblySlave := slave.New("assembly process initiated by master", m.filePath, m.outPath, m.numThreads, m.config, slave.Assembly)
 	if _, err := assemblySlave.Process(); err != nil {
 		return fmt.Errorf("slave assembly process failed with err: %v", err)
 	}
 
-	parserSlave := slave.New("reporting/parse process initiated by master", m.filePath, m.outPath, m.numThreads, slave.Parse)
+	parserSlave := slave.New("reporting/parse process initiated by master", m.filePath, m.outPath, m.numThreads, m.config, slave.Parse)
 	// TODO: Take the result obtained from Parse process and feed it into the reporter
 	results, err := parserSlave.Process()
 	if err != nil {

--- a/master/master.go
+++ b/master/master.go
@@ -17,18 +17,16 @@ import (
 type mst struct {
 	filePath        string                // a path to a raw sequencing FASTQ file to perform assembly on
 	outPath         string                // a path to the location where results will be stored
-	numThreads      int                   // number of threads to use for slave processes
 	config          *config_parser.Config // the configuration of GenoMagic obtained through YAML config file
 	assemblyResults chan result.Result    // a collection of assembly results used by the assembly slave
 	parsingResults  chan result.Result    // a collection of parsing results used by the parsing slave
 }
 
 // New creates and returns a new master struct for the file located at the given file path
-func New(rsf, out string, numThreads int, cfg *config_parser.Config) Master {
+func New(rsf, out string, cfg *config_parser.Config) Master {
 	return &mst{
 		filePath:        rsf,
 		outPath:         out,
-		numThreads:      numThreads,
 		config:          cfg,
 		assemblyResults: make(chan result.Result),
 		parsingResults:  make(chan result.Result),
@@ -37,12 +35,12 @@ func New(rsf, out string, numThreads int, cfg *config_parser.Config) Master {
 
 // Process launches the assembly of the contigs it was created with
 func (m *mst) Process() error {
-	assemblySlave := slave.New("assembly process initiated by master", m.filePath, m.outPath, m.numThreads, m.config, slave.Assembly)
+	assemblySlave := slave.New("assembly process initiated by master", m.filePath, m.outPath, m.config, slave.Assembly)
 	if _, err := assemblySlave.Process(); err != nil {
 		return fmt.Errorf("slave assembly process failed with err: %v", err)
 	}
 
-	parserSlave := slave.New("reporting/parse process initiated by master", m.filePath, m.outPath, m.numThreads, m.config, slave.Parse)
+	parserSlave := slave.New("reporting/parse process initiated by master", m.filePath, m.outPath, m.config, slave.Parse)
 	// TODO: Take the result obtained from Parse process and feed it into the reporter
 	results, err := parserSlave.Process()
 	if err != nil {

--- a/slave/components/assembler/assembler.go
+++ b/slave/components/assembler/assembler.go
@@ -25,7 +25,6 @@ type asmbler struct {
 	assemblerName string                // assembler type e.g MegaHit
 	filePath      string                // path to the file the assembler will operate on
 	outPath       string                // path to the directory where results are stored
-	numThreads    int                   // number of threads to use for assemblers
 	dClient       *client.Client        // the Docker client the assembler will use to spin up containers
 	dImageID      string                // the image ID of the struct assembler
 	config        *config_parser.Config // the GenoMagic configuration as passed through YAML config file
@@ -33,7 +32,7 @@ type asmbler struct {
 }
 
 // New returns a new assembler for the specified file
-func New(fp, op, am string, thrds int, cfg *config_parser.Config) (components.Component, error) {
+func New(fp, op, am string, cfg *config_parser.Config) (components.Component, error) {
 	if constants.AvailableAssemblers[am] == nil {
 		return nil, fmt.Errorf("assembler not recognized")
 	}
@@ -42,7 +41,6 @@ func New(fp, op, am string, thrds int, cfg *config_parser.Config) (components.Co
 		assemblerName: am,
 		filePath:      fp,
 		outPath:       op,
-		numThreads:    thrds,
 		config:        cfg,
 		ctx:           context.Background(),
 	}
@@ -94,7 +92,7 @@ func (a *asmbler) Process() (result.Result, error) {
 	ctConfig := &container.Config{
 		Tty:     true,
 		Image:   a.dImageID,
-		Cmd:     constants.AvailableAssemblers[a.assemblerName].Comm(a.numThreads, *a.config),
+		Cmd:     constants.AvailableAssemblers[a.assemblerName].Comm(*a.config),
 		Volumes: map[string]struct{}{},
 	}
 

--- a/slave/components/assembler/assembler.go
+++ b/slave/components/assembler/assembler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
 
+	"github.com/genomagic/config_parser"
 	"github.com/genomagic/constants"
 	"github.com/genomagic/result"
 	"github.com/genomagic/slave/components"
@@ -21,17 +22,18 @@ import (
 
 // structure of the assembler
 type asmbler struct {
-	assemblerName string          // assembler type e.g MegaHit
-	filePath      string          // path to the file the assembler will operate on
-	outPath       string          // path to the directory where results are stored
-	numThreads    int             // number of threads to use for assemblers
-	dClient       *client.Client  // the Docker client the assembler will use to spin up containers
-	dImageID      string          // the image ID of the struct assembler
-	ctx           context.Context // context of requests performed to the Docker daemon
+	assemblerName string                // assembler type e.g MegaHit
+	filePath      string                // path to the file the assembler will operate on
+	outPath       string                // path to the directory where results are stored
+	numThreads    int                   // number of threads to use for assemblers
+	dClient       *client.Client        // the Docker client the assembler will use to spin up containers
+	dImageID      string                // the image ID of the struct assembler
+	config        *config_parser.Config // the GenoMagic configuration as passed through YAML config file
+	ctx           context.Context       // context of requests performed to the Docker daemon
 }
 
 // New returns a new assembler for the specified file
-func New(fp, op, am string, thrds int) (components.Component, error) {
+func New(fp, op, am string, thrds int, cfg *config_parser.Config) (components.Component, error) {
 	if constants.AvailableAssemblers[am] == nil {
 		return nil, fmt.Errorf("assembler not recognized")
 	}
@@ -41,6 +43,7 @@ func New(fp, op, am string, thrds int) (components.Component, error) {
 		filePath:      fp,
 		outPath:       op,
 		numThreads:    thrds,
+		config:        cfg,
 		ctx:           context.Background(),
 	}
 
@@ -91,7 +94,7 @@ func (a *asmbler) Process() (result.Result, error) {
 	ctConfig := &container.Config{
 		Tty:     true,
 		Image:   a.dImageID,
-		Cmd:     constants.AvailableAssemblers[a.assemblerName].Comm(a.numThreads),
+		Cmd:     constants.AvailableAssemblers[a.assemblerName].Comm(a.numThreads, *a.config),
 		Volumes: map[string]struct{}{},
 	}
 

--- a/slave/slave.go
+++ b/slave/slave.go
@@ -25,18 +25,16 @@ type slv struct {
 	description string                // name/description of the work performed by the slave
 	filePath    string                // the file the slave is supposed to perform work on
 	outPath     string                // a path to the location where results will be stored
-	numThreads  int                   // number of threads to use for slave processes
 	config      *config_parser.Config // the GenoMagic configuration that is passed through YAML config file
 	workType    ComponentWorkType     // the type of work that has to be performed by the slave
 }
 
 // New creates and returns a new instance of a slave
-func New(dsc, fnm, out string, thr int, cfg *config_parser.Config, wtp ComponentWorkType) Slave {
+func New(dsc, fnm, out string, cfg *config_parser.Config, wtp ComponentWorkType) Slave {
 	return &slv{
 		description: dsc,
 		filePath:    fnm,
 		outPath:     out,
-		numThreads:  thr,
 		config:      cfg,
 		workType:    wtp,
 	}
@@ -46,7 +44,7 @@ func New(dsc, fnm, out string, thr int, cfg *config_parser.Config, wtp Component
 func (s *slv) Process() ([]result.Result, error) {
 	if s.workType == Assembly {
 		for k := range constants.AvailableAssemblers {
-			assemblerWorker, err := assembler.New(s.filePath, s.outPath, k, s.numThreads, s.config)
+			assemblerWorker, err := assembler.New(s.filePath, s.outPath, k, s.config)
 			if err != nil {
 				return nil, fmt.Errorf("failed to initialize assembler worker, err %v", err)
 			}

--- a/slave/slave.go
+++ b/slave/slave.go
@@ -5,6 +5,7 @@ package slave
 import (
 	"fmt"
 
+	"github.com/genomagic/config_parser"
 	"github.com/genomagic/constants"
 	"github.com/genomagic/result"
 	"github.com/genomagic/slave/components/assembler"
@@ -21,20 +22,22 @@ type ComponentWorkType string
 
 // slv defines the structure of a slave
 type slv struct {
-	description string            // name/description of the work performed by the slave
-	filePath    string            // the file the slave is supposed to perform work on
-	outPath     string            // a path to the location where results will be stored
-	numThreads  int               // number of threads to use for slave processes
-	workType    ComponentWorkType // the type of work that has to be performed by the slave
+	description string                // name/description of the work performed by the slave
+	filePath    string                // the file the slave is supposed to perform work on
+	outPath     string                // a path to the location where results will be stored
+	numThreads  int                   // number of threads to use for slave processes
+	config      *config_parser.Config // the GenoMagic configuration that is passed through YAML config file
+	workType    ComponentWorkType     // the type of work that has to be performed by the slave
 }
 
 // New creates and returns a new instance of a slave
-func New(dsc, fnm, out string, thr int, wtp ComponentWorkType) Slave {
+func New(dsc, fnm, out string, thr int, cfg *config_parser.Config, wtp ComponentWorkType) Slave {
 	return &slv{
 		description: dsc,
 		filePath:    fnm,
 		outPath:     out,
 		numThreads:  thr,
+		config:      cfg,
 		workType:    wtp,
 	}
 }
@@ -43,7 +46,7 @@ func New(dsc, fnm, out string, thr int, wtp ComponentWorkType) Slave {
 func (s *slv) Process() ([]result.Result, error) {
 	if s.workType == Assembly {
 		for k := range constants.AvailableAssemblers {
-			assemblerWorker, err := assembler.New(s.filePath, s.outPath, k, s.numThreads)
+			assemblerWorker, err := assembler.New(s.filePath, s.outPath, k, s.numThreads, s.config)
 			if err != nil {
 				return nil, fmt.Errorf("failed to initialize assembler worker, err %v", err)
 			}


### PR DESCRIPTION
## Problem/related issue

The problem of incorporating many software specific arguments into genomagic begs a solution where YAML config file is provided containing the configuration parameters for each assemblers, as well as genomagic related assemblers.

## Proposed changes

This PR uses the previously implemented `config_parser` to allow the user to provide configuration to GenoMagic using YAML config files.

## Further comments

@flaviuvadan 