### PR TITLE
Remove Redundant Flags

### DIFF
--- a/config_parser/config.go
+++ b/config_parser/config.go
@@ -2,8 +2,9 @@ package config_parser
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
 )
 
 type (
@@ -22,6 +23,7 @@ type (
 		InputFilePath string `yaml:"inputFilePath"`
 		OutputPath    string `yaml:"outputPath"`
 		Threads       int    `yaml:"threads"`
+		Prep          bool   `yaml:"prep"`
 	}
 
 	MegahitConfig struct {

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 		}
 	}
 
-	mst := master.New(*rawSequenceFile, *out, cfg)
+	mst := master.New(cfg)
 	if err := mst.Process(); err != nil {
 		panic(fmt.Sprintf("failed to run master process, err: %v", err))
 	}

--- a/master/master.go
+++ b/master/master.go
@@ -23,10 +23,10 @@ type mst struct {
 }
 
 // New creates and returns a new master struct for the file located at the given file path
-func New(rsf, out string, cfg *config_parser.Config) Master {
+func New(cfg *config_parser.Config) Master {
 	return &mst{
-		filePath:        rsf,
-		outPath:         out,
+		filePath:        cfg.GenoMagic.InputFilePath,
+		outPath:         cfg.GenoMagic.OutputPath,
 		config:          cfg,
 		assemblyResults: make(chan result.Result),
 		parsingResults:  make(chan result.Result),


### PR DESCRIPTION
## Problem/related issue
Fixes issue: #71

## Proposed changes
Remove `-fastq`, `-prep` and `-out` flag as the `-yaml` flag already replaces those.

## Further comments
@flaviuvadan 