### PR TITLE
Add visualizer package skeleton

### DIFF
--- a/master/master.go
+++ b/master/master.go
@@ -18,7 +18,7 @@ type masterProcess struct {
 	config *config_parser.Config
 }
 
-// New creates and returns a new master struct for the file located at the given file path
+// NewReporter creates and returns a new master struct for the file located at the given file path
 func New(config *config_parser.Config) Master {
 	return &masterProcess{
 		config: config,
@@ -47,7 +47,7 @@ func (m *masterProcess) Process() error {
 
 	var reports []reporter.Reporter
 	for _, r := range results {
-		rep := reporter.New("", r)
+		rep := reporter.NewReporter("", r)
 		if err := rep.Process(); err != nil {
 			return fmt.Errorf("failed to construct report")
 		}

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -21,8 +21,8 @@ type Report struct {
 	L50 int32
 }
 
-// New returns a new instance of a Report
-func New(assemblyName string, result *result.Result) Reporter {
+// NewReporter returns a new instance of a Report that implements the Reporter interface
+func NewReporter(assemblyName string, result *result.Result) Reporter {
 	return &Report{
 		AssemblyName: assemblyName,
 		result:       result,

--- a/reporter/reporter_test.go
+++ b/reporter/reporter_test.go
@@ -90,7 +90,7 @@ func TestReport_Process(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rep := New(TestAssembly, tt.result)
+			rep := NewReporter(TestAssembly, tt.result)
 			if err := rep.Process(); err != nil {
 				assert.EqualError(t, err, tt.expectedErr.Error())
 			}

--- a/visualizer/interfaces.go
+++ b/visualizer/interfaces.go
@@ -1,0 +1,12 @@
+package visualizer
+
+type (
+	// Visualizer represents the interface that is used to interact with the visualizer package. It allows the
+	// construction of specific visualization that can be created after performing assembly and reporting steps
+	Visualizer interface {
+		// N50 creates the plots associated with reporting the N50 scores for assembly reports
+		N50() error
+		// L50 creates the plots associated with reporting the L50 scores for assembly reports
+		L50() error
+	}
+)

--- a/visualizer/visualizer.go
+++ b/visualizer/visualizer.go
@@ -1,0 +1,27 @@
+package visualizer
+
+import "github.com/genomagic/reporter"
+
+type (
+	// visualize implements the Visualizer interface for visualizing assembly reports
+	visualize struct {
+		reports []reporter.Report // the collection of reports to visualize the scores of
+	}
+)
+
+// NewVisualizer creates and returns a new instance of a struct that implements the Visualizer interface
+func NewVisualizer(reports []reporter.Report) Visualizer {
+	return &visualize{
+		reports: reports,
+	}
+}
+
+// N50 creates the plots associated with reporting the N50 scores for assembly reports
+func (v *visualize) N50() error {
+	return nil
+}
+
+// L50 creates the plots associated with reporting the N50 scores for assembly reports
+func (v *visualize) L50() error {
+	return nil
+}


### PR DESCRIPTION
## Problem/related issue

Currently, the results of GenoMagic are not visualized in any manner, only computer by the `reporter` package.

## Proposed changes

Add a skeleton visualizer package to start a discussion around the idea of isolating visualizations into a specific package.

## Further comments

I am thinking about using [go-echarts](https://golangexample.com/a-graceful-data-visualizing-library-for-golang/), which is a Golang visualization tool that was created and publicized by Baidu. I think it would serve the purposes of the visualizer package, which is likely to serve for creating something akin to bar charts/histograms for reporting results for comparison between assemblers. 

@tayabsoomro 