### PR TITLE
update assembler commands to avoid using spaces within fmt.Sprintf func

### DIFF
--- a/constants/assembly.go
+++ b/constants/assembly.go
@@ -70,12 +70,12 @@ var (
 			AssemblyFileName: "final.contigs.fa",
 			Comm: func(cfg *config_parser.Config) []string {
 				var finalCmd = []string{
-					fmt.Sprintf("-r %s", RawSeqIn),
-					fmt.Sprintf("-o %s", path.Join(BaseOut, MegaHitOut)),
+					fmt.Sprintf("--read=%s", RawSeqIn),
+					fmt.Sprintf("--out-dir=%s", path.Join(BaseOut, MegaHitOut)),
 				}
 
 				if cfg.GenoAssist.Threads != 0 {
-					finalCmd = append(finalCmd, fmt.Sprintf("-t %d", cfg.GenoAssist.Threads))
+					finalCmd = append(finalCmd, fmt.Sprintf("--num-cpu-threads=%d", cfg.GenoAssist.Threads))
 				}
 
 				return finalCmd
@@ -90,13 +90,15 @@ var (
 			Comm: func(cfg *config_parser.Config) []string {
 
 				var finalCmd = []string{
-					" name=final",
+					"name=final",
 					fmt.Sprintf("in=%s", RawSeqIn),
 					fmt.Sprintf("--directory=%s", path.Join(BaseOut, AbyssOut)),
 				}
 
 				if cfg.Assemblers.Abyss.KMers != "" {
 					finalCmd = append(finalCmd, fmt.Sprintf("k=%s", cfg.Assemblers.Abyss.KMers))
+				} else {
+					finalCmd = append(finalCmd, fmt.Sprintf("k=25"))
 				}
 
 				if cfg.GenoAssist.Threads != 0 {
@@ -104,7 +106,6 @@ var (
 				}
 
 				finalCmd = append(finalCmd, "contigs")
-
 				return finalCmd
 			},
 			ConditionsPresent: true,
@@ -120,19 +121,22 @@ var (
 			Comm: func(cfg *config_parser.Config) []string {
 
 				finalCommand := []string{
-					fmt.Sprintf("--genome-size %s", cfg.Assemblers.Flye.GenomeSize),
-					fmt.Sprintf("--out-dir %s", path.Join(BaseOut, FlyeOut)),
+					"flye",
+					"--genome-size", cfg.Assemblers.Flye.GenomeSize,
+					"--out-dir", path.Join(BaseOut, FlyeOut),
 				}
 
 				if cfg.GenoAssist.Threads != 0 {
-					finalCommand = append(finalCommand, fmt.Sprintf("--threads %d", cfg.GenoAssist.Threads))
+					finalCommand = append(finalCommand, "--threads")
+					finalCommand = append(finalCommand, fmt.Sprintf("%d", cfg.GenoAssist.Threads))
 				}
 
 				if cfg.Assemblers.Flye.SeqType == "nano" {
-					finalCommand = append(finalCommand, fmt.Sprintf("--nano-raw %s", RawSeqIn))
+					finalCommand = append(finalCommand, "--nano-raw")
 				} else {
-					finalCommand = append(finalCommand, fmt.Sprintf("--pacbio-raw %s", RawSeqIn))
+					finalCommand = append(finalCommand, "--pacbio-raw")
 				}
+				finalCommand = append(finalCommand, RawSeqIn)
 				return finalCommand
 			},
 			ConditionsPresent: false,


### PR DESCRIPTION
## Problem/related issue

Adding spaces within `fmt.Sprintf` function in the string slice doesn't properly register the commands. A working theory is that docker API for GoLang does not register spaces within an item of string slice ( _e.g.,_ `[]string{item1, item2, ...}` ). This is a working theory because the opposite (separating out items with spaces) seems to work.

## Proposed changes

Separate out items that require spaces into their separate items. For example, if item1 is `"flye --genome-size 5m"`, then these will become three separate items: `"flye"`, `"--genome-size"`, `"5m"` within a string slice.

## Further comments

The above explanation isn't comprehensive, and maybe not even necessarily correct. More investigation needs to happen on this issue to figure out what might be causing the problem. But for now, the proposed changes solve the issue and hence are tentatively accepted.