### PR TITLE
Fix filename of the Flye assembler

### DIFF
--- a/constants/assembly.go
+++ b/constants/assembly.go
@@ -117,7 +117,7 @@ var (
 			Name:             Flye,
 			DHubURL:          FlyeDockerURL,
 			OutputDir:        FlyeOut,
-			AssemblyFileName: "final.contigs.fa",
+			AssemblyFileName: "assembly.fasta",
 			Comm: func(cfg *config_parser.Config) []string {
 
 				finalCommand := []string{


### PR DESCRIPTION
## Problem/related issue

Issue #100 documents how the wrong file name is provided to the Flye assembly constants. This results in a `file not found` error, which makes the parser panic.

## Proposed changes

Change the name of the expected assembly file name to `assembly.fasta` from `final.contigs.fa`. This is based on the [documentation for the output of Flye](https://github.com/fenderglass/Flye/blob/flye/docs/USAGE.md#-flye-output). 

[This](https://github.com/genoassist/genoassist/blob/master/replica/components/parser/parser.go#L41) is the line that grabs the assembly name, and [this](https://github.com/genoassist/genoassist/blob/master/constants/assembly.go#L120) is the one that sets it for Flye.

## Further comments

N/A