### PR TITLE
Add file type input

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,18 @@ genoassist:
   threads: 2
   prep: true
   qualityControl: true
+  fileType: "fasta"
 ```
-Notes: 
- - all paths used with GenoAssist have to be absolute paths (a Docker requirement)
- - the accepted assembler values are:
+
+#### Notes: 
+ - All paths used with GenoAssist have to be absolute paths (a Docker requirement)
+ - The accepted assembler values are:
 1. 'abyss'
 1. 'megahit'
 1. 'flye'
+- The accepted file types are:
+1. FASTA
+1. FASTQ
 
 ### Installing Docker images through GenoAssist
 

--- a/config_parser/config.go
+++ b/config_parser/config.go
@@ -3,6 +3,7 @@ package config_parser
 import (
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -26,6 +27,7 @@ type (
 		Threads        int      `yaml:"threads"`
 		Prep           bool     `yaml:"prep"`
 		QualityControl bool     `yaml:"qualityControl"`
+		FileType       string   `yaml:"fileType"`
 	}
 
 	MegahitConfig struct {
@@ -42,6 +44,13 @@ type (
 	}
 )
 
+const (
+	// FASTQ is the FASTQ input type
+	FASTQ = "fastq"
+	// FASTA is the FASTA input type
+	FASTA = "fasta"
+)
+
 // ParseConfig takes in YAML file and returns a config struct
 func ParseConfig(yamlFilePath string) (*Config, error) {
 	config := &Config{}
@@ -51,9 +60,22 @@ func ParseConfig(yamlFilePath string) (*Config, error) {
 		return nil, fmt.Errorf("cannot read file %s, err: %v", yamlFilePath, err)
 	}
 
-	err = yaml.Unmarshal(yamlFile, &config)
-	if err != nil {
+	if err = yaml.Unmarshal(yamlFile, &config); err != nil {
 		return nil, fmt.Errorf("cannot unmarshall the contents of the yamlFile into the struct, err: %v", err)
 	}
+
+	if err = validateConfig(config); err != nil {
+		return nil, fmt.Errorf("failed config validation, err: %s", err)
+	}
+
 	return config, nil
+}
+
+// validateConfig validates the given Config struct for invalid inputs
+func validateConfig(c *Config) error {
+	// TODO: only checking file extension for now, more validation should be added
+	if strings.ToLower(c.GenoAssist.FileType) != FASTQ && strings.ToLower(c.GenoAssist.FileType) != FASTA {
+		return fmt.Errorf("invalid file type, allowed [%s, %s]", FASTQ, FASTA)
+	}
+	return nil
 }

--- a/config_parser/config_test.go
+++ b/config_parser/config_test.go
@@ -15,13 +15,13 @@ func Test_ParseConfig(t *testing.T) {
 		expectedError  error
 	}{
 		{
-			name:           "test_process_returns_nil_on_empty_yaml_file",
+			name:           "test_returns_err_on_empty_config",
 			filePath:       "test1.yaml",
-			expectedConfig: &Config{},
-			expectedError:  nil,
+			expectedConfig: nil,
+			expectedError:  fmt.Errorf("failed config validation, err: invalid file type, allowed [fastq, fasta]"),
 		},
 		{
-			name:     "test_process_returns_expected_config_on_standard_yaml_file",
+			name:     "test_returns_expected_config_on_standard_yaml_file",
 			filePath: "test2.yaml",
 			expectedConfig: &Config{
 				Assemblers: AssemblerConfig{
@@ -37,17 +37,19 @@ func Test_ParseConfig(t *testing.T) {
 					},
 				},
 				GenoAssist: GenoAssistConfig{
-					Assemblers:    []string{"abyss", "megahit", "flye"},
-					InputFilePath: "/test/input1.fastq",
-					OutputPath:    "/test/output",
-					Threads:       2,
-					Prep:          true,
+					Assemblers:     []string{"abyss", "megahit", "flye"},
+					InputFilePath:  "/test/input1.fastq",
+					OutputPath:     "/test/output",
+					Threads:        2,
+					Prep:           true,
+					QualityControl: false,
+					FileType:       FASTA,
 				},
 			},
 			expectedError: nil,
 		},
 		{
-			name:     "test_process_returns_expected_config_on_missing_flye_in_yaml_file",
+			name:     "test_returns_expected_config_on_missing_flye_in_yaml_file",
 			filePath: "test3.yaml",
 			expectedConfig: &Config{
 				Assemblers: AssemblerConfig{
@@ -60,17 +62,19 @@ func Test_ParseConfig(t *testing.T) {
 					Flye: FlyeConfig{},
 				},
 				GenoAssist: GenoAssistConfig{
-					Assemblers:    []string{"abyss", "megahit", "flye"},
-					InputFilePath: "/test/input1.fastq",
-					OutputPath:    "/test/output",
-					Threads:       2,
-					Prep:          true,
+					Assemblers:     []string{"abyss", "megahit", "flye"},
+					InputFilePath:  "/test/input1.fastq",
+					OutputPath:     "/test/output",
+					Threads:        2,
+					Prep:           true,
+					QualityControl: false,
+					FileType:       FASTA,
 				},
 			},
 			expectedError: nil,
 		},
 		{
-			name:     "test_process_returns_expected_config_on_additional_data_in_yaml_file",
+			name:     "test_returns_expected_config_on_additional_data_in_yaml_file",
 			filePath: "test4.yaml",
 			expectedConfig: &Config{
 				Assemblers: AssemblerConfig{
@@ -83,17 +87,19 @@ func Test_ParseConfig(t *testing.T) {
 					Flye: FlyeConfig{},
 				},
 				GenoAssist: GenoAssistConfig{
-					Assemblers:    []string{"abyss", "megahit", "flye"},
-					InputFilePath: "/test/input1.fastq",
-					OutputPath:    "/test/output",
-					Threads:       2,
-					Prep:          true,
+					Assemblers:     []string{"abyss", "megahit", "flye"},
+					InputFilePath:  "/test/input1.fastq",
+					OutputPath:     "/test/output",
+					Threads:        2,
+					Prep:           true,
+					QualityControl: false,
+					FileType:       FASTA,
 				},
 			},
 			expectedError: nil,
 		},
 		{
-			name:     "test_process_returns_expected_config_when_assemblers_are_not_provided",
+			name:     "test_returns_expected_config_when_assemblers_are_not_provided",
 			filePath: "test5.yaml",
 			expectedConfig: &Config{
 				Assemblers: AssemblerConfig{
@@ -106,16 +112,19 @@ func Test_ParseConfig(t *testing.T) {
 					Flye: FlyeConfig{},
 				},
 				GenoAssist: GenoAssistConfig{
-					InputFilePath: "/test/input1.fastq",
-					OutputPath:    "/test/output",
-					Threads:       2,
-					Prep:          true,
+					Assemblers:     nil,
+					InputFilePath:  "/test/input1.fastq",
+					OutputPath:     "/test/output",
+					Threads:        2,
+					Prep:           true,
+					QualityControl: false,
+					FileType:       FASTA,
 				},
 			},
 			expectedError: nil,
 		},
 		{
-			name:     "test_process_returns_expected_config_when_assemblers_dont_follow_correct_capitalization",
+			name:     "test_returns_expected_config_when_assemblers_dont_follow_correct_capitalization",
 			filePath: "test6.yaml",
 			expectedConfig: &Config{
 				Assemblers: AssemblerConfig{
@@ -128,17 +137,19 @@ func Test_ParseConfig(t *testing.T) {
 					Flye: FlyeConfig{},
 				},
 				GenoAssist: GenoAssistConfig{
-					Assemblers:    []string{"abYss", "Megahit", "flye"},
-					InputFilePath: "/test/input1.fastq",
-					OutputPath:    "/test/output",
-					Threads:       2,
-					Prep:          true,
+					Assemblers:     []string{"abYss", "Megahit", "flye"},
+					InputFilePath:  "/test/input1.fastq",
+					OutputPath:     "/test/output",
+					Threads:        2,
+					Prep:           true,
+					QualityControl: false,
+					FileType:       "FaStA",
 				},
 			},
 			expectedError: nil,
 		},
 		{
-			name:     "test_process_returns_expected_config_when_quality_control_option_is_given",
+			name:     "test_returns_expected_config_when_quality_control_option_is_given",
 			filePath: "test7.yaml",
 			expectedConfig: &Config{
 				Assemblers: AssemblerConfig{
@@ -157,12 +168,13 @@ func Test_ParseConfig(t *testing.T) {
 					Threads:        2,
 					Prep:           true,
 					QualityControl: true,
+					FileType:       FASTA,
 				},
 			},
 			expectedError: nil,
 		},
 		{
-			name:     "test_process_returns_expected_config_when_quality_control_option_is_not_given",
+			name:     "test_returns_expected_config_when_quality_control_option_is_not_given",
 			filePath: "test8.yaml",
 			expectedConfig: &Config{
 				Assemblers: AssemblerConfig{
@@ -181,6 +193,7 @@ func Test_ParseConfig(t *testing.T) {
 					Threads:        2,
 					Prep:           true,
 					QualityControl: false,
+					FileType:       FASTA,
 				},
 			},
 			expectedError: nil,

--- a/config_parser/test2.yaml
+++ b/config_parser/test2.yaml
@@ -12,3 +12,4 @@ genoassist:
   outputPath: "/test/output"
   threads: 2
   prep: true
+  fileType: "fasta"

--- a/config_parser/test3.yaml
+++ b/config_parser/test3.yaml
@@ -9,3 +9,4 @@ genoassist:
   outputPath: "/test/output"
   threads: 2
   prep: true
+  fileType: "fasta"

--- a/config_parser/test4.yaml
+++ b/config_parser/test4.yaml
@@ -9,5 +9,6 @@ genoassist:
   outputPath: "/test/output"
   threads: 2
   prep: true
+  fileType: "fasta"
 redundant:
   field: "this is redundant data"

--- a/config_parser/test5.yaml
+++ b/config_parser/test5.yaml
@@ -8,5 +8,6 @@ genoassist:
   outputPath: "/test/output"
   threads: 2
   prep: true
+  fileType: "fasta"
 redundant:
   field: "this is redundant data"

--- a/config_parser/test6.yaml
+++ b/config_parser/test6.yaml
@@ -9,5 +9,6 @@ genoassist:
   outputPath: "/test/output"
   threads: 2
   prep: true
+  fileType: "FaStA"
 redundant:
   field: "this is redundant data"

--- a/config_parser/test7.yaml
+++ b/config_parser/test7.yaml
@@ -10,5 +10,6 @@ genoassist:
   threads: 2
   prep: true
   qualityControl: true
+  fileType: "fasta"
 redundant:
   field: "this is redundant data"

--- a/config_parser/test8.yaml
+++ b/config_parser/test8.yaml
@@ -10,5 +10,6 @@ genoassist:
   threads: 2
   prep: true
   qualityControl: false
+  fileType: "fasta"
 redundant:
   field: "this is redundant data"

--- a/constants/assembly.go
+++ b/constants/assembly.go
@@ -18,9 +18,6 @@ const (
 	// BaseOut is the base directory used as the output, mounted by Docker
 	BaseOut = "/output"
 
-	// RawSeqIn is the mapping of the user-specified reads file to the Docker mount file
-	RawSeqIn = "/raw_sequence_input.fastq"
-
 	// MegaHit specific constants
 	MegaHit          = "megahit"
 	MegaHitOut       = GenoAssist + "_megahit_out"
@@ -70,7 +67,7 @@ var (
 			AssemblyFileName: "final.contigs.fa",
 			Comm: func(cfg *config_parser.Config) []string {
 				var finalCmd = []string{
-					fmt.Sprintf("--read=%s", RawSeqIn),
+					fmt.Sprintf("--read=%s", InputTarget[cfg.GenoAssist.FileType]),
 					fmt.Sprintf("--out-dir=%s", path.Join(BaseOut, MegaHitOut)),
 				}
 
@@ -91,7 +88,7 @@ var (
 
 				var finalCmd = []string{
 					"name=final",
-					fmt.Sprintf("in=%s", RawSeqIn),
+					fmt.Sprintf("in=%s", InputTarget[cfg.GenoAssist.FileType]),
 					fmt.Sprintf("--directory=%s", path.Join(BaseOut, AbyssOut)),
 				}
 
@@ -136,7 +133,7 @@ var (
 				} else {
 					finalCommand = append(finalCommand, "--pacbio-raw")
 				}
-				finalCommand = append(finalCommand, RawSeqIn)
+				finalCommand = append(finalCommand, InputTarget[cfg.GenoAssist.FileType])
 				return finalCommand
 			},
 			ConditionsPresent: false,

--- a/constants/file_types.go
+++ b/constants/file_types.go
@@ -1,0 +1,21 @@
+package constants
+
+const (
+	// NOTE: the FASTQ and FASTA constants are duplicated from config_parser. There would be a circular import if these
+	// would be defined here only. The config parser can be refactored to isolate the Config struct. Currently,
+	// that is the reason why config_parser is imported by this package
+
+	// FASTQ is the FASTQ input type
+	FASTQ = "fastq"
+	// FASTA is the FASTA input type
+	FASTA = "fasta"
+)
+
+var (
+	// InputTarget defines the mapping of the input file type to a file that is mounted to Docker when running
+	// assembly and parsing processes
+	InputTarget = map[string]string{
+		FASTA: "/raw_sequence_input.fasta",
+		FASTQ: "/raw_sequence_input.fastq",
+	}
+)

--- a/replica/components/assembler/assembler.go
+++ b/replica/components/assembler/assembler.go
@@ -107,7 +107,7 @@ func (a *assemblyProcess) Process() (*result.Result, error) {
 			{ // Binding the file provided by the user to the docker container
 				Type:     mount.TypeBind,
 				Source:   a.filePath,
-				Target:   constants.RawSeqIn,
+				Target:   constants.InputTarget[a.config.GenoAssist.FileType],
 				ReadOnly: false,
 			},
 			{ // Binding the output directory provided by the user to the docker container

--- a/replica/components/quality_controller/adapter_trimming.go
+++ b/replica/components/quality_controller/adapter_trimming.go
@@ -49,7 +49,7 @@ func (a *adapterTrimming) Process() (string, error) {
 	ctConfig := &container.Config{
 		Tty: true,
 		Cmd: []string{
-			"-i", constants.RawSeqIn,
+			"-i", constants.InputTarget[a.config.GenoAssist.FileType],
 			"-o", path.Join(constants.BaseOut, trimmedOutputFilename),
 		},
 		Image: img,
@@ -60,7 +60,7 @@ func (a *adapterTrimming) Process() (string, error) {
 			{ // Binding the input raw sequence file provided by the user
 				Type:   mount.TypeBind,
 				Source: a.config.GenoAssist.InputFilePath,
-				Target: constants.RawSeqIn,
+				Target: constants.InputTarget[a.config.GenoAssist.FileType],
 			},
 			{ // Binding the output directory path provided by the user for saving trimmed file in.
 				Type:   mount.TypeBind,


### PR DESCRIPTION
## Problem/related issue

https://github.com/genoassist/genoassist/issues/101 outlines how GenoAssist assumes that the input will always be in FASTQ format. 

## Proposed changes

Allow the user to specify what input file type GenoAssist should use. 

## Further comments

N/A